### PR TITLE
PVADMIN-50364 Fix CVE-2026-41715 in reactor-netty-http

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 reactorPoolVersion=0.2.12
-version=1.0.39.rx1
-reactorNettyQuicVersion=0.0.28
+version=1.0.39.rx2
+reactorNettyQuicVersion=0.0.28.rx2
 reactorCoreVersion=3.4.34
 reactorAddonsVersion=3.4.10
 compatibleVersion=1.0.38

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/Http2ConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -575,7 +575,7 @@ class HttpClientConnect extends HttpClient {
 				}
 
 				Consumer<HttpClientRequest> consumer = null;
-				if (fromURI != null && !toURI.equals(fromURI)) {
+				if (fromURI != null && (!toURI.equals(fromURI) || (fromURI.isSecure() && !toURI.isSecure()))) {
 					if (handler instanceof RedirectSendHandler) {
 						headers.remove(HttpHeaderNames.EXPECT)
 						       .remove(HttpHeaderNames.COOKIE)

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2023 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
+++ b/reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
+++ b/reactor-netty-http/src/test/java/reactor/netty/http/HttpMetricsHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 VMware, Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2026 VMware, Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Back-port the upstream fix for CVE-2026-41715 into the internal reactor-netty fork (base 1.0.39, branch v1.0.39-rx).

h2. CVE-2026-41715 — Cleartext transmission of sensitive information (CWE-319)

Severity: Medium · CVSS v4.0: 4.9

Package: io.projectreactor.netty:reactor-netty-http

Affected: 1.0.0–1.0.51, 1.1.0–1.1.35, 1.2.0–1.2.17, 1.3.0–1.3.5 → our 1.0.39 base IS affected

Fixed in: 1.0.52 (ent), 1.2.18 (oss), 1.3.6 (oss)

Impact: When the HTTP client is explicitly configured to follow redirects, a redirect from a secure (HTTPS) to an insecure (HTTP) endpoint on the same host could leak credentials (Cookie / Authorization / Proxy-Authorization headers) over the unencrypted connection.

Upstream fix commit: e7ef551eead84ba465324531683fafa03ab96ee9 — "Refine header handling during redirects" (https://github.com/reactor/reactor-netty/commit/e7ef551eead84ba465324531683fafa03ab96ee9)

File changed: reactor-netty-http/src/main/java/reactor/netty/http/client/HttpClientConnect.java (1 line — redirect header-stripping condition extended to also fire on secure→insecure redirects)

